### PR TITLE
fix: resolve XPS-9730 build issues and missing packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,12 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
-    branches:
-      - '**'
   schedule:
     - cron: '0 8 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   S3_ENDPOINT: https://s3.sd.kazer.org

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
             echo "matrix={\"target\":[\"$(echo $TARGET_UPPER)\"]}" >> $GITHUB_OUTPUT
           else
             # If not a target-specific branch, include all targets
-            echo "matrix={\"target\":[\"XPS-9730\",\"R710\",\"R630\",\"Z390\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"target\":[\"XPS-9730\"]}" >> $GITHUB_OUTPUT
           fi
 
   # Main build job that uses the determined matrix

--- a/chroot/04_configure.sh
+++ b/chroot/04_configure.sh
@@ -36,4 +36,4 @@ unix_sock_rw_perms = "0770"
 EOF
 
 useradd pierre
-usermod -aG wheel,uucp,audio,video,usb,docker,kvm pierre
+usermod -aG wheel,uucp,audio,video,usb,docker,kvm,plugdev pierre

--- a/files/XPS-9730/etc/portage/package.accept_keywords/evdi
+++ b/files/XPS-9730/etc/portage/package.accept_keywords/evdi
@@ -1,0 +1,1 @@
+x11-drivers/evdi ~amd64

--- a/files/XPS-9730/var/lib/portage/world
+++ b/files/XPS-9730/var/lib/portage/world
@@ -10,6 +10,7 @@ app-editors/vim
 app-emulation/libvirt
 app-emulation/qemu
 app-emulation/virt-manager
+app-eselect/eselect-python
 app-eselect/eselect-repository
 app-misc/jq
 app-misc/tmux
@@ -19,6 +20,8 @@ app-portage/gentoolkit
 app-text/evince
 app-text/wgetpaste
 dev-util/nvidia-cuda-toolkit
+dev-python/jinja2
+dev-util/github-cli
 dev-vcs/git
 media-fonts/fontawesome
 media-fonts/noto


### PR DESCRIPTION
## Summary
- Add `app-eselect/eselect-python` to world file (fixes #15)
- Add `dev-python/jinja2` to world file to ensure python3_12 target (fixes #13, #14)
- Add `dev-util/github-cli` to world file (fixes #17)
- Add `x11-drivers/evdi ~amd64` keyword unmask (fixes #16)
- Add user to `plugdev` group for Yubikey/FIDO2 support (fixes #18)

## Test plan
- [ ] Verify stage4 build completes successfully
- [ ] Verify `eselect python show` works
- [ ] Verify `gh` command is available
- [ ] Verify evdi can be emerged without keyword issues
- [ ] Verify user is in plugdev group after setup

Closes #13, #14, #15, #16, #17, #18